### PR TITLE
Install build-essential in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,7 @@ RUN apt-get update -y \
         wget \
         git \
         jq \
+        build-essential \
         libsasl2-dev \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
## Background

When the action try to install [dbt-spark[pyHive]](https://github.com/datawaves-xyz/dbt_ethereum/blob/main/requirements_ci.txt) which I set via [extra_requirements_txt](https://github.com/datawaves-xyz/dbt_ethereum/blob/main/.github/workflows/action-sqlfluff.yml) option, it will use `gcc` to build `libsasl2`, so I have also added build-essential in Dockerfile.

## How I test the change?

I run this changed action in a forked project, everything looks fine.

```
Run datawaves-xyz/action-sqlfluff@main
/usr/local/bin/docker run --name e[22](https://github.com/datawaves-xyz/dbt_ethereum/runs/6382513493?check_suite_focus=true#step:4:22)6164b8372b0c745dfaa1533e78a3407f6_ab8b31 --label 60e226 --workdir /github/workspace --rm -e SPARK_DATABASE -e SPARK_STS_HOST -e SPARK_STS_PORT -e INPUT_GITHUB_TOKEN -e INPUT_REPORTER -e INPUT_SQLFLUFF_VERSION -e INPUT_SQLFLUFF_COMMAND -e INPUT_CONFIG -e INPUT_PATHS -e INPUT_EXTRA_REQUIREMENTS_TXT -e INPUT_GITHUB_BASE_REF -e INPUT_WORKING-DIRECTORY -e INPUT_LEVEL -e INPUT_FILTER_MODE -e INPUT_FAIL_ON_ERROR -e INPUT_REVIEWDOG_VERSION -e INPUT_FILE_PATTERN -e INPUT_ENCODING -e INPUT_EXCLUDE-RULES -e INPUT_RULES -e INPUT_TEMPLATER -e INPUT_DISABLE-NOQA -e INPUT_DIALECT -e INPUT_PROCESSES -e INPUT_WORKING_DIRECTORY -e REVIEWDOG_LEVEL -e REVIEWDOG_REPORTER -e REVIEWDOG_FILTER_MODE -e REVIEWDOG_FAIL_ON_ERROR -e REVIEWDOG_REVIEWDOG_FLAGS -e REVIEWDOG_ESLINT_FLAGS -e REVIEWDOG_TOOL_NAME -e EXTRA_REQUIREMENTS_TXT -e SQLFLUFF_VERSION -e SQLFLUFF_COMMAND -e SQLFLUFF_CONFIG -e SQLFLUFF_PATHS -e SQLFLUFF_PROCESSES -e SQLFLUFF_EXCLUDE_RULES -e SQLFLUFF_RULES -e SQLFLUFF_TEMPLATER -e SQLFLUFF_DISABLE_NOQA -e SQLFLUFF_DIALECT -e GITHUB_PULL_REQUEST_BASE_REF -e FILE_PATTERN -e HOME -e GITHUB_JOB -e GITHUB_REF -e GITHUB_SHA -e GITHUB_REPOSITORY -e GITHUB_REPOSITORY_OWNER -e GITHUB_RUN_ID -e GITHUB_RUN_NUMBER -e GITHUB_RETENTION_DAYS -e GITHUB_RUN_ATTEMPT -e GITHUB_ACTOR -e GITHUB_WORKFLOW -e GITHUB_HEAD_REF -e GITHUB_BASE_REF -e GITHUB_EVENT_NAME -e GITHUB_SERVER_URL -e GITHUB_API_URL -e GITHUB_GRAPHQL_URL -e GITHUB_REF_NAME -e GITHUB_REF_PROTECTED -e GITHUB_REF_TYPE -e GITHUB_WORKSPACE -e GITHUB_ACTION -e GITHUB_EVENT_PATH -e GITHUB_ACTION_REPOSITORY -e GITHUB_ACTION_REF -e GITHUB_PATH -e GITHUB_ENV -e GITHUB_STEP_SUMMARY -e RUNNER_OS -e RUNNER_ARCH -e RUNNER_NAME -e RUNNER_TOOL_CACHE -e RUNNER_TEMP -e RUNNER_WORKSPACE -e ACTIONS_RUNTIME_URL -e ACTIONS_RUNTIME_TOKEN -e ACTIONS_CACHE_URL -e GITHUB_ACTIONS=true -e CI=true -v "/var/run/docker.sock":"/var/run/docker.sock" -v "/runner/_work/_temp/_github_home":"/github/home" -v "/runner/_work/_temp/_github_workflow":"/github/workflow" -v "/runner/_work/_temp/_runner_file_commands":"/github/file_commands" -v "/runner/_work/dbt_***/dbt_***":"/github/workspace" 60e226:164b8372b0c745dfaa1533e78a3407f6
🐶 Get changed files
🐶 Installing sqlfluff ... https://github.com/sqlfluff/sqlfluff
 Installing extra python modules
 Installing dbt packages
 Running sqlfluff 🐶 ...
 Running reviewdog 🐶 ...
```