### PR TITLE
fix wrong lint exit code

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -70,9 +70,9 @@ if [[ "${SQLFLUFF_COMMAND:?}" == "lint" ]]; then
     $(if [[ "x${SQLFLUFF_TEMPLATER}" != "x" ]]; then echo "--templater ${SQLFLUFF_TEMPLATER}"; fi) \
     $(if [[ "x${SQLFLUFF_DISABLE_NOQA}" != "x" ]]; then echo "--disable-noqa ${SQLFLUFF_DISABLE_NOQA}"; fi) \
     $(if [[ "x${SQLFLUFF_DIALECT}" != "x" ]]; then echo "--dialect ${SQLFLUFF_DIALECT}"; fi) \
-    $changed_files |
-    tee "$lint_results"
+    $changed_files >> "$lint_results"
   sqlfluff_exit_code=$?
+  cat "$lint_results"
 
   echo "::set-output name=sqlfluff-results::$(cat <"$lint_results" | jq -r -c '.')" # Convert to a single line
   echo "::set-output name=sqlfluff-exit-code::${sqlfluff_exit_code}"


### PR DESCRIPTION
fix issue #39

https://github.com/yu-iskw/action-sqlfluff/compare/main...XiChu2333:action-sqlfluff:main#:~:text=%24lint_results%22-,sqlfluff_exit_code%3D%24%3F,-sqlfluff_exit_code%3D%24%3F

Variable sqlfluff_exit_code would receive the return code of command "tee "$lint_results"" instead of the return code sqlfluff.
So, the return code is always 0.
Fix it by using ">>" to replace "tee"