### PR TITLE
support sqlfluff v1.4.5

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ jobs:
           - "1.1.0"
           - "1.2.0"
           - "1.3.0"
+          - "1.4.5"
         config:
           - ".sqlfluff.bigquery"
           - ".sqlfluff.postgres"
@@ -60,6 +61,7 @@ jobs:
           - "1.1.0"
           - "1.2.0"
           - "1.3.0"
+          - "1.4.5"
         config:
           - ".sqlfluff.bigquery"
           - ".sqlfluff.postgres"

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ jobs:
         with:
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-review
-          sqlfluff_version: "1.3.0"
+          sqlfluff_version: "1.4.5"
           sqlfluff_command: "fix" # Or "lint"
           config: "${{ github.workspace }}/.sqlfluff"
           paths: '${{ github.workspace }}/models'
@@ -58,6 +58,7 @@ The tested sqlfluff versions in the repositories are:
 - 1.1.0
 - 1.2.0
 - 1.3.0
+- 1.4.5
 
 ## Input
 
@@ -101,7 +102,7 @@ inputs:
     description: |
       sqlfluff version. Use the latest version if not set.
     required: false
-    default: '1.3.0'
+    default: '1.4.5'
   sqlfluff_command:
     description: 'The sub command of sqlfluff. One of lint and fix'
     required: false

--- a/action.yml
+++ b/action.yml
@@ -44,7 +44,7 @@ inputs:
     description: |
       sqlfluff version. Use the latest version if not set.
     required: false
-    default: '1.3.0'
+    default: '1.4.5'
   sqlfluff_command:
     description: 'The sub command of sqlfluff. One of lint and fix'
     required: false

--- a/testdata/test_failed_dbt/models/staging/staging_test02.sql
+++ b/testdata/test_failed_dbt/models/staging/staging_test02.sql
@@ -2,6 +2,6 @@
 
 
 SELECT
-    1 AS x,
+  1 AS x,
   2 AS y,
   3 AS z


### PR DESCRIPTION
The current release version of sqlfluff is [1.4.5](https://github.com/sqlfluff/sqlfluff/releases/tag/1.4.5). This PR allows for its use in the action.