### PR TITLE
remedy deprecated ::set-output

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -21,8 +21,8 @@ echo "$changed_files"
 # Halt the job
 if [[ "${changed_files}" == "" ]]; then
   echo "There is no changed files. The action doesn't scan files."
-  echo "::set-output name=sqlfluff-exit-code::0"
-  echo "::set-output name=reviewdog-return-code::0"
+  echo "name=sqlfluff-exit-code::0" >> $GITHUB_OUTPUT
+  echo "name=reviewdog-return-code::0" >> $GITHUB_OUTPUT
   exit 0
 fi
 echo '::endgroup::'
@@ -74,8 +74,8 @@ if [[ "${SQLFLUFF_COMMAND:?}" == "lint" ]]; then
     tee "$lint_results"
   sqlfluff_exit_code=$?
 
-  echo "::set-output name=sqlfluff-results::$(cat <"$lint_results" | jq -r -c '.')" # Convert to a single line
-  echo "::set-output name=sqlfluff-exit-code::${sqlfluff_exit_code}"
+  echo "name=sqlfluff-results::$(cat <"$lint_results" | jq -r -c '.')" >> $GITHUB_OUTPUT # Convert to a single line
+  echo "name=sqlfluff-exit-code::${sqlfluff_exit_code}" >> $GITHUB_OUTPUT
 
   set -Eeuo pipefail
   echo '::endgroup::'
@@ -98,8 +98,8 @@ if [[ "${SQLFLUFF_COMMAND:?}" == "lint" ]]; then
       -level="${REVIEWDOG_LEVEL}"
   reviewdog_return_code="${PIPESTATUS[1]}"
 
-  echo "::set-output name=sqlfluff-results-rdjson::$(cat <"$lint_results_rdjson" | jq -r -c '.')" # Convert to a single line
-  echo "::set-output name=reviewdog-return-code::${reviewdog_return_code}"
+  echo "name=sqlfluff-results-rdjson::$(cat <"$lint_results_rdjson" | jq -r -c '.')" >> $GITHUB_OUTPUT # Convert to a single line
+  echo "name=reviewdog-return-code::${reviewdog_return_code}" >> $GITHUB_OUTPUT
 
   set -Eeuo pipefail
   echo '::endgroup::'
@@ -124,7 +124,7 @@ elif [[ "${SQLFLUFF_COMMAND}" == "fix" ]]; then
     $(if [[ "x${SQLFLUFF_DIALECT}" != "x" ]]; then echo "--dialect ${SQLFLUFF_DIALECT}"; fi) \
     $changed_files
   sqlfluff_exit_code=$?   
-  echo "::set-output name=sqlfluff-exit-code::${sqlfluff_exit_code}"
+  echo "name=sqlfluff-exit-code::${sqlfluff_exit_code}" >> $GITHUB_OUTPUT
   
   set -Eeuo pipefail
   echo '::endgroup::'


### PR DESCRIPTION
Github have deprecated `::set-output` and have presented the recommended new way to implement the same functionality. There is write-up about it [here](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/). 

This PR implements those recommendations and will remove the deprecation warning when this github action runs.