### PR TITLE
Fix parse error: Invalid numeric literal

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
           paths: '${{ github.workspace }}/testdata/test_failed_dbt/models'
           extra_requirements_txt: "${{ github.workspace }}/testdata/test_failed_dbt/extra_requirements.txt"
       - name: check the exit code
-        if: ${{ !success() }}
+        if: ${{ success() }}
         run: echo 'The previous step should fail' && exit 1
       - name: "Test outputs"
         if: always()

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -64,6 +64,7 @@ if [[ "${SQLFLUFF_COMMAND:?}" == "lint" ]]; then
   # shellcheck disable=SC2086,SC2046
   sqlfluff lint \
     --format json \
+    --write-output $lint_results \
     $(if [[ "x${SQLFLUFF_CONFIG}" != "x" ]]; then echo "--config ${SQLFLUFF_CONFIG}"; fi) \
     $(if [[ "x${SQLFLUFF_DIALECT}" != "x" ]]; then echo "--dialect ${SQLFLUFF_DIALECT}"; fi) \
     $(if [[ "x${SQLFLUFF_PROCESSES}" != "x" ]]; then echo "--processes ${SQLFLUFF_PROCESSES}"; fi) \
@@ -72,8 +73,7 @@ if [[ "${SQLFLUFF_COMMAND:?}" == "lint" ]]; then
     $(if [[ "x${SQLFLUFF_TEMPLATER}" != "x" ]]; then echo "--templater ${SQLFLUFF_TEMPLATER}"; fi) \
     $(if [[ "x${SQLFLUFF_DISABLE_NOQA}" != "x" ]]; then echo "--disable-noqa ${SQLFLUFF_DISABLE_NOQA}"; fi) \
     $(if [[ "x${SQLFLUFF_DIALECT}" != "x" ]]; then echo "--dialect ${SQLFLUFF_DIALECT}"; fi) \
-    $changed_files |
-    tee "$lint_results"
+    $changed_files
   sqlfluff_exit_code=$?
 
   echo "name=sqlfluff-results::$(cat <"$lint_results" | jq -r -c '.')" >> $GITHUB_OUTPUT # Convert to a single line

--- a/testdata/test_failed_dbt/models/staging/staging_test02.sql
+++ b/testdata/test_failed_dbt/models/staging/staging_test02.sql
@@ -2,6 +2,6 @@
 
 
 SELECT
-    1 AS x,
+  1 AS x,
   2 AS y,
   3 AS z

--- a/testdata/test_failed_dbt/models/staging/staging_test02.sql
+++ b/testdata/test_failed_dbt/models/staging/staging_test02.sql
@@ -3,5 +3,5 @@
 
 SELECT
   1 AS x,
-  2 AS y,
+    2 AS y,
   3 AS z

--- a/testdata/test_failed_dbt/models/staging/staging_test02.sql
+++ b/testdata/test_failed_dbt/models/staging/staging_test02.sql
@@ -3,5 +3,5 @@
 
 SELECT
   1 AS x,
-    2 AS y,
+  2 AS y,
   3 AS z


### PR DESCRIPTION
When piping `sqlfluff lint` into `tee`, exit code becomes 0 instead of 1. 
This causes `parse error: Invalid numeric literal`.
To fix it, we persist the lint output using `--write-output` CLI flag from sqlfluff instead of using `tee`.

fix #31 #43