### PR TITLE
feat: add extra-args input for sqlfluff lint/fix commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,10 @@ inputs:
       Multiple rules can be specified with commas e.g. –exclude-rules L001,L002 will exclude violations of rule L001 and rule L002.
     required: false
     default: ""
+  extra-args:
+    description: 'Extra arguments to pass directly to sqlfluff lint/fix'
+    required: false
+    default: ""
   rules:
     description: |
       Narrow the search to only specific rules.

--- a/action.yml
+++ b/action.yml
@@ -78,6 +78,10 @@ inputs:
       Multiple rules can be specified with commas e.g. –exclude-rules L001,L002 will exclude violations of rule L001 and rule L002.
     required: false
     default: ""
+  extra-args:
+    description: 'Extra arguments to pass directly to sqlfluff lint/fix'
+    required: false
+    default: ""
   rules:
     description: |
       Narrow the search to only specific rules.
@@ -167,6 +171,7 @@ runs:
     SQLFLUFF_PATHS: ${{ inputs.paths }}
     SQLFLUFF_PROCESSES: ${{ inputs.processes }}
     SQLFLUFF_EXCLUDE_RULES: ${{ inputs.exclude-rules }}
+    SQLFLUFF_EXTRA_ARGS: ${{ inputs.extra-args }}
     SQLFLUFF_RULES: ${{ inputs.rules }}
     SQLFLUFF_TEMPLATER: ${{ inputs.templater }}
     SQLFLUFF_DISABLE_NOQA: ${{ inputs.disable-noqa }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -75,6 +75,7 @@ if [[ ${SQLFLUFF_COMMAND:?} == "lint" ]]; then
 		$(if [[ "x${SQLFLUFF_TEMPLATER}" != "x" ]]; then echo "--templater ${SQLFLUFF_TEMPLATER}"; fi) \
 		$(if [[ "x${SQLFLUFF_DISABLE_NOQA}" != "x" ]]; then echo "--disable-noqa ${SQLFLUFF_DISABLE_NOQA}"; fi) \
 		$(if [[ "x${SQLFLUFF_DIALECT}" != "x" ]]; then echo "--dialect ${SQLFLUFF_DIALECT}"; fi) \
+		${SQLFLUFF_EXTRA_ARGS} \
 		$changed_files |
 		tee "$lint_results"
 	sqlfluff_exit_code=$?
@@ -127,6 +128,7 @@ elif [[ ${SQLFLUFF_COMMAND} == "fix" ]]; then
 		$(if [[ "x${SQLFLUFF_TEMPLATER}" != "x" ]]; then echo "--templater ${SQLFLUFF_TEMPLATER}"; fi) \
 		$(if [[ "x${SQLFLUFF_DISABLE_NOQA}" != "x" ]]; then echo "--disable-noqa ${SQLFLUFF_DISABLE_NOQA}"; fi) \
 		$(if [[ "x${SQLFLUFF_DIALECT}" != "x" ]]; then echo "--dialect ${SQLFLUFF_DIALECT}"; fi) \
+		${SQLFLUFF_EXTRA_ARGS} \
 		$changed_files
 	sqlfluff_exit_code=$?
 	echo "name=sqlfluff-exit-code::${sqlfluff_exit_code}" >>$GITHUB_OUTPUT


### PR DESCRIPTION
### **User description**
### Summary

This PR adds support for passing additional CLI arguments to `sqlfluff lint` and `sqlfluff fix` via a new input `extra-args`.

### Motivation

It addresses [#143](https://github.com/yu-iskw/action-sqlfluff/issues/143), allowing users to customize behavior (e.g. `--ignore parsing`) in a flexible way.

### Changes

- Added `extra-args` input in `action.yml` and exposed it as `SQLFLUFF_EXTRA_ARGS`
- Used it in `entrypoint.sh` for both `lint` and `fix` commands
- Updated `README.md` to document this input

### Example usage

```yaml
- uses: action-sqlfluff@x.x.x
  with:
    dialect: postgres
    extra-args: '--ignore parsing'
```

___

### **PR Type**
Enhancement


___

### **Description**
- Add `extra-args` input for custom sqlfluff arguments

- Support additional CLI flags in lint/fix commands

- Enable flexible sqlfluff behavior customization


___

### **Changes diagram**

```mermaid
flowchart LR
  A["action.yml"] --> B["extra-args input"]
  B --> C["SQLFLUFF_EXTRA_ARGS env var"]
  C --> D["entrypoint.sh"]
  D --> E["sqlfluff lint command"]
  D --> F["sqlfluff fix command"]
  G["README.md"] --> H["documentation update"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>action.yml</strong><dd><code>Add extra-args input configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

action.yml

<li>Add <code>extra-args</code> input definition with description<br> <li> Export input as <code>SQLFLUFF_EXTRA_ARGS</code> environment variable


</details>


  </td>
  <td><a href="https://github.com/yu-iskw/action-sqlfluff/pull/145/files#diff-1243c5424efaaa19bd8e813c5e6f6da46316e63761421b3e5f5c8ced9a36e6b6">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>entrypoint.sh</strong><dd><code>Integrate extra-args into sqlfluff commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

entrypoint.sh

<li>Extract <code>EXTRA_ARGS</code> from <code>INPUT_EXTRA_ARGS</code> environment variable<br> <li> Append extra arguments to both sqlfluff lint and fix commands


</details>


  </td>
  <td><a href="https://github.com/yu-iskw/action-sqlfluff/pull/145/files#diff-6f9d41d046756f0ddc2fcee0626bdb50100d12b88f293734eff742818e03efa2">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document extra-args input parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<li>Document new <code>extra-args</code> input parameter<br> <li> Add description for passing custom arguments to sqlfluff


</details>


  </td>
  <td><a href="https://github.com/yu-iskw/action-sqlfluff/pull/145/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details> 
 <div id='description'>
    <a href="https://bito.ai#summarystart"></a>
<h3>Summary by Bito</h3>
This pull request enhances the sqlfluff action by adding support for an 'extra-args' input, allowing users to customize sqlfluff lint and fix commands. It addresses issue #143 and includes updates to action.yml, entrypoint.sh, and README.md for documentation.
<!-- Disabling unit_tests and post_effort_to_review
<br>
<br>
<b>Unit tests added</b>: False
<br>
<br>
<b>Estimated effort to review (1-5, lower is better)</b>: 2 - The changes are straightforward and well-documented, making the review process relatively simple.
-->
</div>